### PR TITLE
Uncomment vertex AI project settings in configuration file

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -34,6 +34,6 @@ commitable_code_suggestions = true
 demand_code_suggestions_self_review = true
 summarize = false
 
-# [vertexai]
-# vertex_project = "haru256-pr-agent"
-# vertex_location = ""
+[vertexai]
+vertex_project = "haru256-pr-agent"
+vertex_location = ""

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -33,7 +33,3 @@ rank_suggestions = true
 commitable_code_suggestions = true
 demand_code_suggestions_self_review = true
 summarize = false
-
-[vertexai]
-vertex_project = "haru256-pr-agent"
-vertex_location = ""


### PR DESCRIPTION
This pull request updates the `.pr_agent.toml` configuration file to enable the `vertexai` section by uncommenting and modifying its settings.

Configuration updates:

* [`.pr_agent.toml`](diffhunk://#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7L37-R39): Enabled the `vertexai` section by uncommenting it and setting `vertex_project` to `"haru256-pr-agent"` while leaving `vertex_location` as an empty string.