### PR TITLE
Remove gcloud info step from PR Agent workflow and update README for clarity

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -24,9 +24,6 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }} # 出力値を登録
           service_account: ${{ vars.GCP_SA_EMAIL }} # 出力値を登録
 
-      - name: "gcloud info"
-        run: gcloud info
-
       - name: "PR Agent action step"
         id: pragent
         uses: qodo-ai/pr-agent@main

--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@
 qudo-aiのpr-agentのためのリポジトリ
 <https://github.com/qodo-ai/pr-agent>
 
+以下を行っている
+
 - サンプルGithub Action
 - PR-Agentで使用する各種LLM系の設定(e.g. Vertex AI)


### PR DESCRIPTION
This pull request includes minor changes to clean up the GitHub Actions workflow and improve the `README.md` file documentation.

### Workflow cleanup:
* Removed the `gcloud info` step from the `.github/workflows/pr_agent.yml` file, as it was deemed unnecessary.

### Documentation improvement:
* Updated the `README.md` file to include a brief description of the repository's purpose and the actions it performs.